### PR TITLE
Fix Motorcycle constructor parameter

### DIFF
--- a/Uppgift5 Garage/Vehicles/Motorcycle.cs
+++ b/Uppgift5 Garage/Vehicles/Motorcycle.cs
@@ -9,9 +9,9 @@ namespace Uppgift5_Garage.Vehicles
     public class Motorcycle : Vehicle
     {
         public int CylinderVolume { get; set; }
-        public Motorcycle(string regNr, string color, int wheels, int cylinerVolume) : base(regNr, color, wheels)
+        public Motorcycle(string regNr, string color, int wheels, int cylinderVolume) : base(regNr, color, wheels)
         {
-            CylinderVolume = cylinerVolume;
+            CylinderVolume = cylinderVolume;
         }
 
         public override string Describe()


### PR DESCRIPTION
## Summary
- correct typo in `Motorcycle` constructor parameter name

## Testing
- `dotnet test --no-build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6862a3b2b2f083209df6c51b47b3cda7